### PR TITLE
Add "license" so ADO org admins see in Marketplace

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -18,6 +18,9 @@
     "content": {
         "details": {
             "path": "overview.md"
+        },
+        "license": {
+            "path": "eula.md"
         }
     },
     "icons": {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -20,7 +20,7 @@
             "path": "overview.md"
         },
         "license": {
-            "path": "eula.md"
+            "path": "LICENSE"
         }
     },
     "icons": {


### PR DESCRIPTION
Fix for #32, adding license path to vss-extension.json