### PR TITLE
Add unit tests for the extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Run unit tests
+      run: npm test
+
+    - name: Generate coverage report
+      run: npx nyc npm test

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "tsc -p .",
     "postbuild": "npm run package",
     "package": "tfx extension create",
-    "clean": "rimraf ./dist && rimraf ./*.vsix"
+    "clean": "rimraf ./dist && rimraf ./*.vsix",
+    "test": "mocha --require ts-node/register tests/**/*.test.ts"
   },
   "repository": {
     "type": "git",
@@ -21,5 +22,10 @@
     "tfx-cli": "^0.6.4",
     "typescript": "^4.0.5",
     "vss-web-extension-sdk": "^4.125.2"
+  },
+  "devDependencies": {
+    "mocha": "^8.3.2",
+    "chai": "^4.3.4",
+    "nyc": "^15.1.0"
   }
 }

--- a/publishhtmlreport/package.json
+++ b/publishhtmlreport/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha --require ts-node/register tests/**/*.test.ts"
   },
   "author": "",
   "license": "ISC",
@@ -15,6 +15,9 @@
     "@types/node": "^10.17.44",
     "@types/q": "^1.5.4",
     "cheerio": "^1.0.0-rc.6",
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.2",
+    "mocha": "^8.3.2",
+    "chai": "^4.3.4",
+    "nyc": "^15.1.0"
   }
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import { run } from '../publishhtmlreport/index';
+import * as tl from 'azure-pipelines-task-lib/task';
+import * as fs from 'fs';
+import * as cheerio from 'cheerio';
+
+describe('publishhtmlreport', () => {
+  beforeEach(() => {
+    // Mock the task library functions
+    tl.getInput = (name: string, required?: boolean) => {
+      if (name === 'htmlType') {
+        return 'Jmeter';
+      } else if (name === 'JmeterReportsPath') {
+        return 'test-reports';
+      }
+      return '';
+    };
+
+    // Mock the file system functions
+    fs.readFileSync = (path: string) => {
+      if (path === 'test-reports/index.html') {
+        return '<html><body><div id="generalInfos"><table><tbody><tr><td></td><td>test.jmx</td></tr></tbody></table></div></body></html>';
+      } else if (path === 'test-reports/content/js/dashboard.js') {
+        return 'console.log("dashboard.js");';
+      } else if (path === 'test-reports/content/js/graph.js') {
+        return 'console.log("graph.js");';
+      }
+      return '';
+    };
+
+    // Mock the cheerio load function
+    cheerio.load = (html: string) => {
+      return cheerio.load(html);
+    };
+  });
+
+  it('should run the task successfully', async () => {
+    await run();
+    expect(tl.setResult).to.have.been.calledWith(tl.TaskResult.Succeeded);
+  });
+
+  it('should fail the task with bad input', async () => {
+    tl.getInput = (name: string, required?: boolean) => {
+      if (name === 'htmlType') {
+        return 'bad';
+      }
+      return '';
+    };
+
+    await run();
+    expect(tl.setResult).to.have.been.calledWith(tl.TaskResult.Failed, 'Bad input was given');
+  });
+});


### PR DESCRIPTION
Fixes #25

Add unit test cases and CI pipeline for the extension.

* **package.json**: Add `mocha`, `chai`, and `nyc` as dev dependencies. Add a `test` script to run unit tests using `mocha`.
* **publishhtmlreport/package.json**: Add `mocha`, `chai`, and `nyc` as dev dependencies. Add a `test` script to run unit tests using `mocha`.
* **tests/index.test.ts**: Create a new test file for unit tests of `publishhtmlreport/index.ts`. Write unit tests for the `run` function.
* **.github/workflows/ci.yml**: Create a new GitHub Actions workflow file for CI pipeline. Add steps to install dependencies, run unit tests, and generate coverage report.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lakshaykaushik/PublishHTMLReport/issues/25?shareId=039bbab1-b71e-46b1-9402-e041dc69c752).